### PR TITLE
Ad Hoc Metrics Page

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -65,6 +65,12 @@ func setIndexViewData(c *middleware.Context) (*dtos.IndexViewData, error) {
 	    Url:  setting.AppSubUrl + "/hosts",
 	})
 
+	data.MainNavLinks = append(data.MainNavLinks, &dtos.NavLink{
+	    Text: "Metrics",
+	    Icon: "icon-gf icon-gf-search",
+	    Url: setting.AppSubUrl + "/dashboard/metrics",
+	})
+
 	// data.MainNavLinks = append(data.MainNavLinks, &dtos.NavLink{Text: "Playlists", Icon: "fa fa-fw fa-list", Url: setting.AppSubUrl + "/playlists"})
 	// data.MainNavLinks = append(data.MainNavLinks, &dtos.NavLink{Text: "Snapshots", Icon: "fa-fw icon-gf icon-gf-snapshot", Url: setting.AppSubUrl + "/dashboard/snapshots"})
 

--- a/public/app/core/routes/dashboard_loaders.js
+++ b/public/app/core/routes/dashboard_loaders.js
@@ -43,4 +43,14 @@ function (coreModule) {
     }, $scope);
   });
 
+  coreModule.default.controller('MetricsCtrl', function($scope) {
+    $scope.initDashboard({
+      meta: { canStar: false, canShare: false, adHocDashboard: true},
+      dashboard: {
+        title: " ",
+        rows: [{ height: '250px', panels:[] }]
+      },
+    }, $scope);
+  });
+
 });

--- a/public/app/core/routes/routes.ts
+++ b/public/app/core/routes/routes.ts
@@ -45,6 +45,12 @@ function setupAngularRoutes($routeProvider, $locationProvider) {
     reloadOnSearch: false,
     pageClass: 'page-dashboard',
   })
+  .when('/dashboard/metrics', {
+    templateUrl: 'public/app/partials/dashboard.html',
+    controller : 'MetricsCtrl',
+    reloadOnSearch: true,
+    pageClass: 'page-dashboard',
+  })
   .when('/import/dashboard', {
     templateUrl: 'public/app/features/dashboard/partials/import.html',
     controller : 'DashboardImportCtrl',

--- a/public/app/features/dashboard/dashnav/dashnav.html
+++ b/public/app/features/dashboard/dashnav/dashnav.html
@@ -1,6 +1,6 @@
 <navbar>
 
-<div class="top-nav-btn dashnav-dashboards-btn" ng-if="!dashboardMeta.isSnapshot">
+<div class="top-nav-btn dashnav-dashboards-btn" ng-if="!dashboardMeta.isSnapshot" ng-show="!dashboardMeta.adHocDashboard">
 	<a class="pointer" ng-click="openSearch()">
 		<i class="icon-gf icon-gf-dashboard"></i>
 		<span class="dashboard-title">{{dashboard.title}}</span>
@@ -8,7 +8,7 @@
 	</a>
 </div>
 
-<div class="top-nav-btn dashnav-dashboards-btn" ng-if="dashboardMeta.isSnapshot">
+<div class="top-nav-btn dashnav-dashboards-btn" ng-if="dashboardMeta.isSnapshot" ng-show="!dashboardMeta.adHocDashboard">
 	<a class="pointer" bs-tooltip="titleTooltip" data-placement="bottom" ng-click="openSearch()">
 		<i class="icon-gf icon-gf-snapshot"></i>
 		<span class="dashboard-title">
@@ -18,7 +18,7 @@
 	</a>
 </div>
 
-<ul class="nav pull-left dashnav-action-icons">
+<ul class="nav pull-left dashnav-action-icons" ng-show="!dashboardMeta.adHocDashboard">
 	<li ng-show="dashboardMeta.canStar">
 		<a class="pointer" ng-click="starDashboard()">
 			<i class="fa" ng-class="{'fa-star-o': !dashboardMeta.isStarred, 'fa-star': dashboardMeta.isStarred}" style="color: orange;"></i>
@@ -70,7 +70,7 @@
 </ul>
 
 <ul class="nav pull-right">
-	<li ng-show="dashboard.meta.fullscreen" class="dashnav-back-to-dashboard">
+	<li ng-show="dashboard.meta.fullscreen && !dashboard.meta.adHocDashboard" class="dashnav-back-to-dashboard">
 		<a ng-click="exitFullscreen()">
 			Back to dashboard
 		</a>

--- a/public/app/features/dashboard/rowCtrl.js
+++ b/public/app/features/dashboard/rowCtrl.js
@@ -8,7 +8,7 @@ function (angular, _, config) {
 
   var module = angular.module('grafana.controllers');
 
-  module.controller('RowCtrl', function($scope, $rootScope, $timeout) {
+  module.controller('RowCtrl', function($scope, $rootScope, $timeout, $location) {
     var _d = {
       title: "Row",
       height: "150px",
@@ -21,6 +21,27 @@ function (angular, _, config) {
 
     $scope.init = function() {
       $scope.editor = {index: 0};
+      if ($location.path() === '/dashboard/metrics') {
+        var defaultSpan = 12;
+        var _as = 12 - $scope.dashboard.rowSpan($scope.row);
+
+        var panel = {
+          title: config.new_panel_title,
+          error: false,
+          span: _as < defaultSpan && _as > 0 ? _as : defaultSpan,
+          editable: true,
+          type: 'graph'
+        };
+
+        $scope.addPanel(panel);
+
+        $scope.dashboardViewState.update({fullscreen: true, edit: panel, panelId: 1});
+        $scope.dashboardMeta.canEdit = true;
+        $scope.dashboardMeta.canShare = false;
+        $scope.dashboardMeta.canSave = false;
+        $scope.dashboardMeta.canStar = false;
+        $scope.dashboardMeta.adHocDashboard = true;
+      }
     };
 
     $scope.togglePanelMenu = function(posX) {

--- a/public/app/features/panel/panel_directive.ts
+++ b/public/app/features/panel/panel_directive.ts
@@ -18,7 +18,7 @@ var panelTemplate = `
         <i class="fa fa-spinner fa-spin"></i>
       </span>
 
-      <div class="panel-title-container drag-handle" panel-menu></div>
+      <div class="panel-title-container drag-handle" ng-show="!ctrl.dashboard.meta.adHocDashboard" panel-menu></div>
     </div>
 
     <div class="panel-content">
@@ -40,7 +40,7 @@ var panelTemplate = `
           </div>
         </div>
 
-        <button class="gf-box-header-close-btn" ng-click="ctrl.exitFullscreen();">
+        <button class="gf-box-header-close-btn" ng-click="ctrl.exitFullscreen();" ng-show="!ctrl.dashboard.meta.adHocDashboard">
           Back to dashboard
         </button>
       </div>

--- a/public/app/partials/metrics.html
+++ b/public/app/partials/metrics.html
@@ -1,5 +1,9 @@
 <div class="editor-row">
 
+	<div>
+	    <span><b>Graphite Namespace:</b><br>collector.region.cluster.hostname.your_metric_here</span>
+	</div>
+
 	<div class="tight-form-container">
 		<div ng-repeat="target in ctrl.panel.targets" ng-class="{'tight-form-disabled': target.hide}">
 			<rebuild-on-change property="ctrl.panel.datasource || target.datasource" show-null="true">

--- a/public/app/plugins/panel/graph/module.ts
+++ b/public/app/plugins/panel/graph/module.ts
@@ -103,7 +103,9 @@ class GraphCtrl extends MetricsPanelCtrl {
     _.defaults(this.panel.grid, panelDefaults.grid);
     _.defaults(this.panel.legend, panelDefaults.legend);
 
-    this.colors = $scope.$root.colors;
+    if ($scope.$root){
+      this.colors = $scope.$root.colors;
+    }
   }
 
   initEditMode() {


### PR DESCRIPTION
Thanks to George for finding the patch that inspired this.

Adds a metrics option to the nav that takes you to an adhoc dashboard to start metrics searching.
Also decided to add the namespacing instructions above the query builder (site-wide, not just on this adhoc dash) so people know what to do.
